### PR TITLE
Add Bedrock LevelDB Chunk Releated Output Array Format Documentation

### DIFF
--- a/Bedrock/LevelDB_Output_Array_Formats/LegacyBlockExtraData_Format.md
+++ b/Bedrock/LevelDB_Output_Array_Formats/LegacyBlockExtraData_Format.md
@@ -1,0 +1,23 @@
+# Legacy Block Extra Data (`4`) Format
+
+## Byte Order
+
+LegacyBlockExtraData is stored in **Little Endian** byte order.
+
+## Parsing The LegacyBlockExtraData
+
+| Name | Size (in bytes) | Description |
+|------|-----------------|-------------|
+| Extra Block Count | 4 | The number of extra blocks in this chunk |
+
+Now loop the next section `Extra Block Count` times until you have parsed all extra blocks.
+
+| Name | Size (in bytes) | Description |
+|------|-----------------|-------------|
+| <a id="block-location-index"></a> Block Location Index | 4 | The extra block location within this chunk represented as the index into the blockId array[\[1\]](#1) |
+| Block ID | 1 | The extra blocks Id |
+| Block Data | 1 | The extra blocks data value |
+
+## Notes
+
+1. <a id="1"></a> If used with Subchunks *([Subchunk Versions 0, 2 - 7](./Subchunk_Format.md#if-version-is-0-or-between-2-and-7))* the [Block Location Index](#block-location-index) stores the coordintes relative to the subchunk instead with the first byte containing the Y value in the right 4 bits, and the second byte containing the X value in the left 4 bits, and the Z value in the right 4 bits. The last 2 bytes are unused in this case. the index can then be calculated with `X × 16 × 16 + Z × 16 + Y`.

--- a/Bedrock/LevelDB_Output_Array_Formats/LegacyTerrain_Format.md
+++ b/Bedrock/LevelDB_Output_Array_Formats/LegacyTerrain_Format.md
@@ -1,0 +1,22 @@
+# Legacy Terrain (`0`) Format
+
+## Byte Order
+
+LegacyTerrain bytes are stored in **Little Endian** byte order.
+
+## Parsing The LegacyTerrain
+
+| Name | Size (in bytes) | Description |
+|------|-----------------|-------------|
+| Block IDs | 32,768 | Block IDs defining the terrain. 8 bits per block, stored in YZX order[\[1\]](#1) (Y increments first) |
+| Block Data | 16,384 | Block data additionally defining parts of the terrain. 4 bits per block, stored in YZX order (Y increments first) |
+| Sky light | 16,384 | The amount of sunlight or moonlight hitting each block. 4 bits per block, stored in YZX order (Y increments first) |
+| Block light | 16,384 | The amount of block-emitted light in each block. 4 bits per block, stored in YZX order (Y increments first) |
+| Heightmap | 256 | Each byte records the lowest level in each column where the light from the sky is at full strength. Stored in YZX order (Y increments first) |
+| 2D Biome data | 1,024 | Each entry of the biome array contains a biome ID in the first byte, and the final 3 bytes are red/green/blue color values respectively |
+
+## Related
+Second block layer for LegacyTerrain: [LegacyBlockExtraData (`4`)](./LegacyBlockExtraData_Format.md)
+
+## Notes
+1. <a id="1"></a> Index is calculated with `(X << 11) | (Z << 7) | Y`

--- a/Bedrock/LevelDB_Output_Array_Formats/Subchunk_Format.md
+++ b/Bedrock/LevelDB_Output_Array_Formats/Subchunk_Format.md
@@ -1,0 +1,60 @@
+# Subchunk (`/`) Data Format
+
+## Byte Order
+
+Subchunk data is stored in **Little Endian** byte order.
+
+## Parsing The Subchunk
+
+**NOTE:** Bedrock subchunks are only saved to disk if they have changed since world generation.
+
+| Name | Size (in bytes) | Description |
+|------|-----------------|-------------|
+| Version | 1 | The version of this subchunk. |
+
+### If Version is 8 and 9
+
+| Name | Size (in bytes) | Description |
+|------|-----------------|-------------|
+| Block Layer Count | 1 | The number of block layers this subchunk has. |
+| Y-Index | 1 | The Subchunk Y Position (ranges from -4 to 19). (Only exists if ***Version*** is 9) |
+
+Now loop the next section `Block Layer Count` times until you have parsed all block layers.
+
+| Name | Size (in bits) | Description |
+|------|----------------|-------------|
+| Palette Type | 1 | The type of this palette (0 = Persistence, 1 = Runtime) |
+| <a id="bits-per-word"></a> Bits Per [Word](https://en.wikipedia.org/wiki/Word_(computer_architecture)) | 7 | How many bits are used for each word. |
+
+#### If Palette Type is 0
+
+| Name | Size (in bytes) | Description |
+|------|-----------------|-------------|
+| Layer Indices | ceil(4096[\[1\]](#1) ÷ *Blocks Per Word[\[2\]](#2))* × 4 | Stored as *Blocks Per Word* indices, with each unsigned 32-bit integer containing multiple indices, each occupying ***Bits Per Word*** bits. The indices are packed and stored in YZX order (Y increments first). |
+| NBT Palette Compound Count | 4 | The number of NBT compounds to parse |
+| NBT Palette Compounds | Variable | Multiple NBT compounds of individual blocks of the palette used in this subchunk |
+
+#### If Palette Type is 1 (Might not be used in practice)
+
+| Name | Size (in bytes) | Description |
+|------|-----------------|-------------|
+| Layer Indices | ceil(4096[\[1\]](#1) ÷ *Blocks Per Word[\[2\]](#2))* × 4 | Stored as *Blocks Per Word* indices, with each unsigned 32-bit integer containing multiple indices, each occupying ***Bits Per Word*** bits. The indices are packed and stored in YZX order (Y increments first). |
+| NBT Palette Compound Count | 1 Signed VarInt ([ZigZag](https://gist.github.com/mfuerstenau/ba870a29e16536fdbaba)) | The number of NBT compounds to parse |
+| NBT Palette Compounds | Variable | Multiple NBT compounds of individual blocks of the palette used in this subchunk |
+
+<hr style="height:5px;margin-top:25px">
+
+### If Version is 0 or between 2 and 7
+
+**NOTE:** Second block layer for this version uses [LegacyBlockExtraData (`4`)](./LegacyBlockExtraData_Format.md) key instead, rather then being stored with the subchunk like in newer versions of the format.
+
+| Name | Size (in bytes) | Description |
+|------|-----------------|-------------|
+| Block IDs | 4096 | 8 bits per block. All the block ids for this chunk stored in YZX order (Y increments first) |
+| Block Data | 2048 | 4 bits per block. All the data values for the blocks in this chunk stored in YZX order (Y increments first) |
+| Skylight | 2048 | 4 bits per block. May be omitted. All the skylight data for this chunk stored in YZX order (Y increments first) |
+| Blocklight | 2048 | 4 bits per block. May be omitted. All the blocklight data for this chunk stored in YZX order (Y increments first) |
+
+## Notes
+1. <a id="1"></a> In some languages you may need to write this as `4096.0` instead of just `4096` for the correct output.
+2. <a id="2"></a> Blocks Per Word = floor(32 ÷ [Bits Per Word](#bits-per-word))

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub contributors](https://img.shields.io/github/contributors/Team-Lodestone/Documentation)
 [![Lodestone Discord](https://img.shields.io/discord/1029594598084968530?color=7a60fc&label=Project%20Lodestone%20Discord&logo=Discord&logoColor=white)](https://discord.gg/umHRdX6R7V)
 
-In this repo, you'll find documentation on various mechanics and file types for the Legacy Console and 3DS editions of the game.
+In this repo, you'll find documentation on various mechanics and file types for Bedrock, Legacy Console, and 3DS editions of the game.
 
 # What is Project Lodestone?
 


### PR DESCRIPTION
I have documented the output arrays of Bedrocks chunk related formats from version 0.9.0 to the latest release (3 formats) 

I plan on adding other docs for other output array formats from LevelDB soon as well.